### PR TITLE
FIX [starter] Disable strict host key checking

### DIFF
--- a/src/start/ssh.rs
+++ b/src/start/ssh.rs
@@ -33,6 +33,7 @@ impl RemoteProcess {
     fn create_ssh_command(&self) -> Command {
         let mut command = Command::new("ssh");
         command
+            .arg("-o StrictHostKeyChecking=no")
             .arg(&self.host)
             .arg("/bin/sh")
             .stdin(Stdio::piped())


### PR DESCRIPTION
This allows to start remote workers on unauthorized nodes using "rain start".