### PR TITLE
Change memory usage calculation

### DIFF
--- a/src/common/monitor.rs
+++ b/src/common/monitor.rs
@@ -84,7 +84,7 @@ impl Monitor {
     fn get_mem_usage(&self) -> MemUsage {
         if cfg!(target_os = "linux") || cfg!(target_os = "macos") {
             (match mem_info() {
-                Ok(meminfo) => 100 * (meminfo.total - meminfo.free) / meminfo.total,
+                Ok(meminfo) => 100 * (meminfo.total - meminfo.avail) / meminfo.total,
                 Err(_) => 0,
             }) as MemUsage
         } else {


### PR DESCRIPTION
Worker memory usage is currently calculated with this expression:
`100 * (meminfo.total - meminfo.free) / meminfo.total`

This counts Linux file buffers and caches as unusable memory.
In the dashboard it may unintuitively show that the worker is almost OOM, while in reality it may have plenty of available memory.
The cached memory is ephemeral and won't even cause a swap if any application asks for more memory.
Linux even has a special field in /proc/meminfo to calculate the "real" available memory, because the `free` attribute is not a good approximation in this regard (https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=34e431b0ae398fc54ea69ff85ec700722c9da773).

This patch changes it to
`100 * (meminfo.total - meminfo.avail) / meminfo.total`
which reduced the displayed memory usage of a worker on my machine from 97 % to 37 %.
I haven't tested it on Windows nor OS X, but the documentation of the `sys-info` crate doesn't state anything about `avail` being unavailable on those systems.