### PR TITLE
Configuration of own subworkers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -616,6 +616,7 @@ dependencies = [
  "tokio-process 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-timer 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-uds 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "toml 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "walkdir 2.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1055,6 +1056,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "serde 1.0.30 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "ucd-util"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1291,6 +1300,7 @@ dependencies = [
 "checksum tokio-threadpool 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "19a8656c45ae7893c9090ac5c98749e7ff904932973fabd541463f82628efacb"
 "checksum tokio-timer 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6131e780037787ff1b3f8aad9da83bca02438b72277850dd6ad0d455e0e20efc"
 "checksum tokio-uds 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "65ae5d255ce739e8537221ed2942e0445f4b3b813daebac1c0050ddaaa3587f9"
+"checksum toml 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "a0263c6c02c4db6c8f7681f9fd35e90de799ebd4cfdeab77a38f4ff6b3d8c0d9"
 "checksum ucd-util 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "fd2be2d6639d0f8fe6cdda291ad456e23629558d466e2789d2c3e9892bda285d"
 "checksum unicase 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "284b6d3db520d67fbe88fd778c21510d1b0ba4a551e5d0fbb023d33405f6de8a"
 "checksum unicode-width 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "bf3a113775714a22dcb774d8ea3655c53a32debae63a063acc00a91cc586245f"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,7 @@ serde_derive = "*"
 serde = "*"
 serde_json = "*"
 tar = "*"
+toml = "*"
 walkdir = "*"
 
 [build-dependencies]

--- a/capnp/subworker.capnp
+++ b/capnp/subworker.capnp
@@ -39,6 +39,8 @@ struct Task {
 
     attributes @3 :Attributes;
 
+    method @4 :Text;
+
     struct InDataObject {
         id @0 :DataObjectId;
         data @1 :LocalData;

--- a/python/rain/client/pycode.py
+++ b/python/rain/client/pycode.py
@@ -181,4 +181,4 @@ class Remote:
             'encode_outputs': [o.attributes['spec'].get('encode') for o in output_objs]
         }
 
-        return Task("py", task_config, input_objs, output_objs, cpus=self.cpus)
+        return Task("py/", task_config, input_objs, output_objs, cpus=self.cpus)

--- a/src/worker/tasks/instance.rs
+++ b/src/worker/tasks/instance.rs
@@ -170,11 +170,14 @@ impl TaskInstance {
     fn start_task_in_subworker(state: &mut State, task_ref: TaskRef) -> TaskResult {
         let (future, method_name) = {
             let task = task_ref.get();
-            let tokens : Vec<_> = task.task_type.split('/').collect();
+            let tokens: Vec<_> = task.task_type.split('/').collect();
             if tokens.len() != 2 {
                 bail!("Invalid task_type, does not contain '/'");
             }
-            (state.get_subworker(tokens.get(0).unwrap())?, tokens.get(1).unwrap().to_string())
+            (
+                state.get_subworker(tokens.get(0).unwrap())?,
+                tokens.get(1).unwrap().to_string(),
+            )
         };
         let state_ref = state.self_ref();
         Ok(Box::new(future.and_then(move |subworker| {


### PR DESCRIPTION
It adds (in little bit hack-like way) a configuration option for worker:
```
--config CONFIGFILE
```
where CONFIGFILE is a path to a toml file that may configure the worker; right now you can define own subworkers:

```
[subworkers.abc]
    command = "/path/to/binary args"
```

this defines subworker "abc" and all tasks with task config "abs/XXX" will be redirected to this subworker.

By default, "py" subworker for Python is defined; however, it can be overridden by the config file.