### PR TITLE
[ci] add cargo test and style checks to Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,3 +6,5 @@ notifications:
     slack: substantic:FJsopazpmJ5siyjfWCW36CVj
 script:
   - docker run -u 123 -e RAIN_TEST_BIN=/rain/target/release/rain rain pytest -x -v --timeout=300
+  - docker run rain /bin/bash -c '. $HOME/.cargo/env && cargo test'
+  - docker run rain /bin/bash -c '. $HOME/.cargo/env && utils/checks/stylecheck.sh'

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,8 @@ RUN apt-get update && \
     curl https://sh.rustup.rs -sSf | sh -s -- -y && \
     . $HOME/.cargo/env && \
     cargo install capnpc && \
-    pip3 install pycapnp cloudpickle pytest pytest-timeout cbor pyarrow && \
+    rustup component add rustfmt-preview && \
+    pip3 install pycapnp cloudpickle flake8 pytest pytest-timeout cbor pyarrow && \
     cargo build --all-features --release --verbose && \
     cd python && \
     python3 setup.py install


### PR DESCRIPTION
This adds cargo tests and style checks to Travis, those things should be ran after each commit/merge on Github.