### PR TITLE
Session events

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get update && \
     . $HOME/.cargo/env && \
     cargo install capnpc && \
     rustup component add rustfmt-preview && \
-    pip3 install pycapnp cloudpickle flake8 pytest pytest-timeout cbor pyarrow && \
+    pip3 install pycapnp cloudpickle flake8 pytest pytest-timeout cbor pyarrow requests && \
     cargo build --all-features --release --verbose && \
     cd python && \
     python3 setup.py install

--- a/dashboard/src/components/Workers.js
+++ b/dashboard/src/components/Workers.js
@@ -11,8 +11,8 @@ class Workers extends Component {
 
   constructor(props) {
     super(props);
-    this.state = {workers: []}
-    this.unsubscribe = fetch_events({"event_type": {value: "Monitoring", mode: "="}}, event => {
+    this.state = {workers: []};
+    this.unsubscribe = fetch_events({"event_types": [{value: "Monitoring", mode: "="}]}, event => {
       //console.log("EVENT", event);
       let index = -1;
       let i = 0;

--- a/dashboard/src/utils/fetch.js
+++ b/dashboard/src/utils/fetch.js
@@ -46,7 +46,7 @@ export function fetch_events(search_criteria, callback, on_error, update) {
             clearInterval(timer);
             timer = null;
         });
-    }
+    };
 
     _fetch_events();
     let timer = setInterval(_fetch_events, 1000);

--- a/src/common/events.rs
+++ b/src/common/events.rs
@@ -36,6 +36,11 @@ pub struct SessionNewEvent {
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct SessionCloseEvent {
+    pub session: SessionId,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct ClientSubmitEvent {
     pub tasks: Vec<TaskDescriptor>,
     pub dataobjs: Vec<ObjectDescriptor>,
@@ -144,6 +149,7 @@ pub enum Event {
     ClientRemoved(ClientRemovedEvent),
 
     SessionNew(SessionNewEvent),
+    SessionClose(SessionCloseEvent),
 
     ClientSubmit(ClientSubmitEvent),
     ClientUnkeep(ClientUnkeepEvent),
@@ -168,6 +174,7 @@ impl Event {
             &Event::ClientNew(_) => "ClientNew",
             &Event::ClientRemoved(_) => "ClientRemoved",
             &Event::SessionNew(_) => "SessionNew",
+            &Event::SessionClose(_) => "SessionClose",
             &Event::ClientSubmit(_) => "ClientSubmit",
             &Event::ClientUnkeep(_) => "ClientUnkeep",
             &Event::TaskStarted(_) => "TaskStarted",
@@ -186,6 +193,7 @@ impl Event {
             &Event::TaskStarted(ref e) => Some(e.task.get_session_id()),
             &Event::TaskFailed(ref e) => Some(e.task.get_session_id()),
             &Event::SessionNew(ref e) => Some(e.session),
+            &Event::SessionClose(ref e) => Some(e.session),
             &Event::ClientSubmit(ref e) => {
                 // TODO: Quick hack, we expect that submit contains only tasks/obj from one session
                 e.tasks.get(0).map(|t| t.id.get_session_id())

--- a/src/common/logging/logger.rs
+++ b/src/common/logging/logger.rs
@@ -20,7 +20,7 @@ pub struct SearchItemString {
 #[derive(Deserialize)]
 pub struct SearchCriteria {
     pub id: Option<SearchItemInt>,
-    pub event_type: Option<SearchItemString>,
+    pub event_types: Option<Vec<SearchItemString>>,
     pub session: Option<SearchItemInt>,
 }
 
@@ -126,9 +126,7 @@ pub trait Logger {
     }
 
     fn add_close_session_event(&mut self, session: SessionId) {
-        self.add_event(Event::SessionClose(events::SessionCloseEvent {
-            session,
-        }));
+        self.add_event(Event::SessionClose(events::SessionCloseEvent { session }));
     }
 
     fn get_events(

--- a/src/common/logging/logger.rs
+++ b/src/common/logging/logger.rs
@@ -31,7 +31,7 @@ pub trait Logger {
         self.add_event_with_timestamp(event, Utc::now());
     }
 
-    fn add_event_with_timestamp(&mut self, event: Event, ::chrono::DateTime<::chrono::Utc>);
+    fn add_event_with_timestamp(&mut self, event: Event, time: ::chrono::DateTime<::chrono::Utc>);
 
     fn flush_events(&mut self);
 
@@ -122,6 +122,12 @@ pub trait Logger {
         self.add_event(Event::SessionNew(events::SessionNewEvent {
             session,
             client,
+        }));
+    }
+
+    fn add_close_session_event(&mut self, session: SessionId) {
+        self.add_event(Event::SessionClose(events::SessionCloseEvent {
+            session,
         }));
     }
 

--- a/src/common/logging/sqlite_logger.rs
+++ b/src/common/logging/sqlite_logger.rs
@@ -61,9 +61,15 @@ fn load_events(conn: &mut Connection, search_criteria: &SearchCriteria) -> Resul
         args.push(&v.value);
     }
 
-    if let Some(ref v) = search_criteria.event_type {
-        where_conds.push(make_where_string("event_type", &v.mode)?);
-        args.push(&v.value);
+    if let Some(ref v) = search_criteria.event_types {
+        let conditions: Result<Vec<_>> = v.iter()
+            .map(|e| make_where_string("event_type", &e.mode))
+            .collect();
+        where_conds.push(format!("({})", conditions?.join(" OR ")));
+
+        for event in v {
+            args.push(&event.value);
+        }
     }
 
     if let Some(ref v) = search_criteria.session {

--- a/src/server/state.rs
+++ b/src/server/state.rs
@@ -198,6 +198,8 @@ impl State {
         }
         // Remove all finish hooks
         s.get_mut().finish_hooks.clear();
+
+        self.logger.add_close_session_event(session_id);
         Ok(())
     }
 

--- a/tests/pytests/conftest.py
+++ b/tests/pytests/conftest.py
@@ -53,6 +53,7 @@ class Env:
 class TestEnv(Env):
 
     default_listen_port = "17010"
+    default_http_port = "17011"
     running_port = None
 
     def __init__(self):
@@ -77,6 +78,7 @@ class TestEnv(Env):
               n_cpus=1,
               listen_addr=None,
               listen_port=None,
+              http_port=None,
               worker_defs=None,
               delete_list_timeout=None):
         """
@@ -108,6 +110,9 @@ class TestEnv(Env):
                 port = self.default_listen_port
         self.running_port = port
 
+        if not http_port:
+            http_port = self.default_http_port
+
         server_ready_file = os.path.join(WORK_DIR, "server-ready")
 
         assert (n_workers is None) != (worker_defs is None)
@@ -121,7 +126,8 @@ class TestEnv(Env):
         args = (RAIN_BIN, "server",
                 "--ready-file", server_ready_file,
                 "--logdir", os.path.join(WORK_DIR, "server"),
-                "--listen", str(addr))
+                "--listen", str(addr),
+                "--http-listen", str(http_port))
         self.server = self.start_process("server", args, env=env)
         assert self.server is not None
 

--- a/tests/pytests/test_events.py
+++ b/tests/pytests/test_events.py
@@ -1,0 +1,28 @@
+from time import sleep
+
+import requests
+
+
+def test_event_filter(test_env):
+    test_env.start(1)
+    with test_env.client.new_session() as session:
+        session_id = session.session_id
+
+    sleep(1)
+
+    data = {
+        "event_types": [
+            {"value": "SessionClose", "mode": "="},
+            {"value": "SessionNew", "mode": "="}]
+    }
+
+    res = requests.post('http://localhost:{}/events'.format(test_env.default_http_port), json=data)
+    events = res.json()
+
+    assert len(events) == 2
+    assert events[0]['event']['session'] == session_id
+    assert events[0]['event']['session'] == events[1]['event']['session']
+
+    by_id = sorted(events, key=lambda ev: ev['id'])
+    assert by_id[0]['event']['type'] == 'SessionNew'
+    assert by_id[1]['event']['type'] == 'SessionClose'


### PR DESCRIPTION
This PR adds session close event, enables querying for multiple event types and adds event tests.

It takes a while before the events are written to the DB, so the test sleeps for 1 sec. But since testing this interface is non-critical, I think that it can be marked as a slow test and it's not a problem that it is a bit flaky.